### PR TITLE
Make a minor update to remove a warning

### DIFF
--- a/aframe.html
+++ b/aframe.html
@@ -58,7 +58,7 @@
         </a-mixin>
       </a-assets>
 
-      <a-camera universal-controls></a-camera>
+      <a-camera universal-controls='rotationEnabled: false;'></a-camera>
       <a-sky color="#ECECEC"></a-sky>
 
       <a-entity>


### PR DESCRIPTION
The warning itself didn't actually seem to have an adverse effect on your scene, but I wanted to be sure, so I went ahead and modified your code slightly to get rid of the message. I re-tested, and everything appeared to be working fine.

Just to summarize my results: I was able to move around your scene using my gamepad with no modifications to your code at all. The one thing I'd mention is that I had to use the _left_ analog stick -- the right wasn't responding to anything. I suspect that the right stick would be used for rotation if things were properly configured for it, but that configuration is beyond me at the moment. For now, it's probably easier, (on your stomach at the very least), to handle rotation by actually physically turning your head.

One last thing of note -- While in VR, I noticed significant "artifact flickering", which I'm distinguishing from the intentional flicker you added to the scene. With that said, I think the latter is causing the former. Basically, I kept seeing white boxes flickering on to the screen at regular intervals, and I _didn't_ notice the nice flicker effect that was present when I was looking via browser.  With that said, if you haven't noticed it, it might just be a matter of my hardware.